### PR TITLE
Downgrade mercurius from 10.1.0 to 10.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "fastify": "^4.3.0",
         "fluent-json-schema": "^3.1.0",
         "graphql": "^16.5.0",
-        "mercurius": "^10.1.0",
+        "mercurius": "10.0.0",
         "pg": "^8.7.3",
         "pino-pretty": "^8.1.0",
         "postgrator-cli": "^6.0.0",
@@ -5841,9 +5841,9 @@
       }
     },
     "node_modules/mercurius": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/mercurius/-/mercurius-10.1.0.tgz",
-      "integrity": "sha512-7CBxRcxRELyGDz2FernU2dogyJ2b7Vp4JBUx68Pn082xNH97Oel/Mt4yPpn7V2V1bY7MyuxSF+oZLzFlG+5jCw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mercurius/-/mercurius-10.0.0.tgz",
+      "integrity": "sha512-qLhiKCaIg1oF6wMcegMIzjx0S6JmwLWV+6Z+z6zSiZpSnivHnaIrI5BQUMSdqiJQ3jbvzc4wMXQFJAYApA7qEw==",
       "dependencies": {
         "@fastify/error": "^3.0.0",
         "@fastify/static": "^6.0.0",
@@ -5854,7 +5854,7 @@
         "graphql-jit": "^0.7.3",
         "mqemitter": "^5.0.0",
         "p-map": "^4.0.0",
-        "readable-stream": "^4.0.0",
+        "readable-stream": "^3.6.0",
         "safe-stable-stringify": "^2.3.0",
         "secure-json-parse": "^2.4.0",
         "single-user-cache": "^0.6.0",
@@ -5867,17 +5867,6 @@
       },
       "peerDependencies": {
         "graphql": "^16.0.0"
-      }
-    },
-    "node_modules/mercurius/node_modules/readable-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.1.0.tgz",
-      "integrity": "sha512-sVisi3+P2lJ2t0BPbpK629j8wRW06yKGJUcaLAGXPAUhyUxVJm7VsCTit1PFgT4JHUDMrGNR+ZjSKpzGaRF3zw==",
-      "dependencies": {
-        "abort-controller": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/merge-stream": {
@@ -15461,9 +15450,9 @@
       }
     },
     "mercurius": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/mercurius/-/mercurius-10.1.0.tgz",
-      "integrity": "sha512-7CBxRcxRELyGDz2FernU2dogyJ2b7Vp4JBUx68Pn082xNH97Oel/Mt4yPpn7V2V1bY7MyuxSF+oZLzFlG+5jCw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mercurius/-/mercurius-10.0.0.tgz",
+      "integrity": "sha512-qLhiKCaIg1oF6wMcegMIzjx0S6JmwLWV+6Z+z6zSiZpSnivHnaIrI5BQUMSdqiJQ3jbvzc4wMXQFJAYApA7qEw==",
       "requires": {
         "@fastify/error": "^3.0.0",
         "@fastify/static": "^6.0.0",
@@ -15474,23 +15463,13 @@
         "graphql-jit": "^0.7.3",
         "mqemitter": "^5.0.0",
         "p-map": "^4.0.0",
-        "readable-stream": "^4.0.0",
+        "readable-stream": "^3.6.0",
         "safe-stable-stringify": "^2.3.0",
         "secure-json-parse": "^2.4.0",
         "single-user-cache": "^0.6.0",
         "tiny-lru": "^8.0.1",
         "undici": "^5.0.0",
         "ws": "^8.2.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.1.0.tgz",
-          "integrity": "sha512-sVisi3+P2lJ2t0BPbpK629j8wRW06yKGJUcaLAGXPAUhyUxVJm7VsCTit1PFgT4JHUDMrGNR+ZjSKpzGaRF3zw==",
-          "requires": {
-            "abort-controller": "^3.0.0"
-          }
-        }
       }
     },
     "merge-stream": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "fastify": "^4.3.0",
     "fluent-json-schema": "^3.1.0",
     "graphql": "^16.5.0",
-    "mercurius": "^10.1.0",
+    "mercurius": "10.0.0",
     "pg": "^8.7.3",
     "pino-pretty": "^8.1.0",
     "postgrator-cli": "^6.0.0",


### PR DESCRIPTION
Currently, as reported in [issue 228 on the project board](https://github.com/orgs/nearform/projects/6/views/1), tests for `step-03-executable-schema` time out.

After looking through the commit history, it seems to have started failing when dependabot upgraded mercerius to 10.1.0.

I have reran all the tests to see if downgrading affects the others, and on my machine it doesn't appear to.

<img width="855" alt="Screenshot 2022-08-02 at 16 34 46" src="https://user-images.githubusercontent.com/58425475/182414251-e1f7c92b-9ccb-4c6c-b090-5d35699bb0b9.png">

[Related issue](https://github.com/nearform/the-graphql-workshop/issues/228)