### PR TITLE
Updates to individual readme and step 9 query types

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -895,7 +895,7 @@ export { createService }
 ```js
 const schema = `
   type Query {
-    add(x: Int, y: Int): Int
+    add(x: Int!, y: Int!): Int
   }
 `
 

--- a/slides.md
+++ b/slides.md
@@ -177,7 +177,7 @@ export default function buildServer() {
 // graphql.js
 const schema = `
   type Query {
-    add(x: Int, y: Int): Int
+    add(x: Int!, y: Int!): Int
   }
 `
 
@@ -413,7 +413,7 @@ export default function buildServer() {
 // graphql.js
 const typeDefs = `
   type Query {
-    add(x: Int, y: Int): Int
+    add(x: Int!, y: Int!): Int
   }
 `
 

--- a/src/start-here/package.json
+++ b/src/start-here/package.json
@@ -1,8 +1,0 @@
-{
-  "main": "server.js",
-  "type": "module",
-  "scripts": {
-    "start": "node server",
-    "test": "echo 'todo'"
-  }
-}

--- a/src/step-01-basic/README.md
+++ b/src/step-01-basic/README.md
@@ -8,7 +8,7 @@ Server is running on port 3000
 
 ## Running the example
 
-Send a graphQL request with the following query:
+Send a graphQL request to http://localhost:3000/graphql with the following query:
 
 ```js
 { 

--- a/src/step-01-basic/graphql.js
+++ b/src/step-01-basic/graphql.js
@@ -1,6 +1,6 @@
 const schema = `
   type Query {
-    add(x: Int, y: Int): Int
+    add(x: Int!, y: Int!): Int
   }
 `
 

--- a/src/step-02-loaders/README.md
+++ b/src/step-02-loaders/README.md
@@ -8,7 +8,7 @@ Server is running on port 3000
 
 ## Running the example
 
-Send a graphQL request with the following query:
+Send a graphQL request to http://localhost:3000/graphql with the following query:
 
 ```js
 {

--- a/src/step-03-executable-schema/README.md
+++ b/src/step-03-executable-schema/README.md
@@ -8,7 +8,7 @@ Server is running on port 3000
 
 ## Running the example
 
-Send a graphQL request with the following query:
+Send a graphQL request to http://localhost:3000/graphql with the following query:
 
 ```js
 { 

--- a/src/step-03-executable-schema/graphql.js
+++ b/src/step-03-executable-schema/graphql.js
@@ -1,6 +1,6 @@
 const typeDefs = `
   type Query {
-    add(x: Int, y: Int): Int
+    add(x: Int!, y: Int!): Int
   }
 `
 

--- a/src/step-04-n+1/README.md
+++ b/src/step-04-n+1/README.md
@@ -8,7 +8,7 @@ Server is running on port 3000
 
 ## Running the example
 
-Send a graphQL request with the following query:
+Send a graphQL request to http://localhost:3000/graphql with the following query:
 
 ```js
 { 

--- a/src/step-05-context/README.md
+++ b/src/step-05-context/README.md
@@ -8,7 +8,7 @@ Server is running on port 3000
 
 ## Running the example
 
-Send a graphQL request with the following query:
+Send a graphQL request to http://localhost:3000/graphql with the following query:
 
 ```js
 { 

--- a/src/step-06-hooks/README.md
+++ b/src/step-06-hooks/README.md
@@ -8,7 +8,7 @@ Server is running on port 3000
 
 ## Running the example
 
-Send a graphQL request with the following query:
+Send a graphQL request to http://localhost:3000/graphql with the following query:
 
 ```js
 { 

--- a/src/step-06-hooks/graphql.js
+++ b/src/step-06-hooks/graphql.js
@@ -1,6 +1,6 @@
 const schema = `
   type Query {
-    add(x: Int, y: Int): Int
+    add(x: Int!, y: Int!): Int
   }
 `
 

--- a/src/step-07-error-handling/README.md
+++ b/src/step-07-error-handling/README.md
@@ -8,7 +8,7 @@ Server is running on port 3000
 
 ## Running the example
 
-Send a graphQL request with the following query:
+Send a graphQL request to http://localhost:3000/graphql with the following query:
 
 ```js
 { 

--- a/src/step-08-federation/README.md
+++ b/src/step-08-federation/README.md
@@ -4,4 +4,4 @@
 
 - start the server with `npm start`
 
-Server is running on port 4000
+Server is running on port 4000 and http://localhost:4000/graphiql can be used to browse the federated schemas

--- a/src/step-09-variables/README.md
+++ b/src/step-09-variables/README.md
@@ -8,7 +8,7 @@ Server is running on port 3000
 
 ## Running the example
 
-Send a graphQL request with the following query:
+Send a graphQL request to http://localhost:3000/graphql with the following query:
 
 ```js
 query AddQuery ($x: Int!, $y: Int!) {

--- a/src/step-09-variables/graphql.js
+++ b/src/step-09-variables/graphql.js
@@ -1,6 +1,6 @@
 const schema = `
   type Query {
-    add(x: Int, y: Int): Int
+    add(x: Int!, y: Int!): Int
   }
 `
 

--- a/src/step-10-fragments/README.md
+++ b/src/step-10-fragments/README.md
@@ -8,7 +8,7 @@ Server is running on port 3000
 
 ## Running the example
 
-Send a graphQL request with the following query:
+Send a graphQL request to http://localhost:3000/graphql with the following query:
 
 ```js
 {


### PR DESCRIPTION
Fixes #384 

- I initially used the Readme files in each step and there was no mention about where to send requests (novices to graphql potentially don't know that the endpoint is at `/graphql`, so I updated individual docs
- The query types for step 9 didn't have variables as being required, so a user could send a query resulting in `NaN` issues when trying to perform the addition.
- There was no reference to the "start-here" directory, and it didn't look like a template to add more steps, so I deleted it