### PR TITLE
fix: rewritten loader logic so it orders owners by pets

### DIFF
--- a/migrations/002.do.sql
+++ b/migrations/002.do.sql
@@ -1,2 +1,2 @@
 INSERT INTO owners (name) VALUES ('Jennifer'), ('Simon');
-INSERT INTO pets (name, owner) VALUES ('Max', 1), ('Charlie', 2);
+INSERT INTO pets (name, owner) VALUES ('Max', 2), ('Charlie', 1);

--- a/slides.md
+++ b/slides.md
@@ -468,7 +468,10 @@ const loaders = {
   Pet: {
     async owner(queries, context) {
       const petNames = queries.map(({ obj }) => obj.name)
-      return ownersByPetNames(context.app.pg, petNames)
+      const owners = await ownersByPetNames(context.app.pg, petNames)
+      return queries.map(({ obj: pet }) =>
+        owners.find(owner => owner.id === pet.owner)
+      )
     }
   }
 }
@@ -676,9 +679,7 @@ onResolution called
   "errors": [
     {
       "message": "Invalid User ID",
-      "locations": [
-        { "line": 2, "column": 3 }
-      ],
+      "locations": [{ "line": 2, "column": 3 }],
       "path": ["findUser"],
       "extensions": {
         "code": "USER_ID_INVALID",
@@ -796,7 +797,6 @@ await gateway.listen({ port: 4000 })
 ---
 
 # Step 8: Solution / 2
-
 
 ```js
 // index.js

--- a/slides.md
+++ b/slides.md
@@ -456,6 +456,8 @@ export async function ownersByPetNames(db, petNames) {
       INNER JOIN pets
         ON pets.owner = owners.id
         AND pets.name = ANY(${petNames})
+      ORDER BY
+        ARRAY_POSITION((${petNames}), pets.name)`
     `
   )
 
@@ -468,10 +470,7 @@ const loaders = {
   Pet: {
     async owner(queries, context) {
       const petNames = queries.map(({ obj }) => obj.name)
-      const owners = await ownersByPetNames(context.app.pg, petNames)
-      return queries.map(({ obj: pet }) =>
-        owners.find(owner => owner.id === pet.owner)
-      )
+      return ownersByPetNames(context.app.pg, petNames)
     }
   }
 }

--- a/src/step-04-n+1/graphql.js
+++ b/src/step-04-n+1/graphql.js
@@ -27,10 +27,7 @@ const loaders = {
   Pet: {
     async owner(queries, context) {
       const petNames = queries.map(({ obj }) => obj.name)
-      const owners = await ownersByPetNames(context.app.pg, petNames)
-      return queries.map(({ obj: pet }) =>
-        owners.find(owner => owner.id === pet.owner)
-      )
+      return ownersByPetNames(context.app.pg, petNames)
     }
   }
 }

--- a/src/step-04-n+1/graphql.js
+++ b/src/step-04-n+1/graphql.js
@@ -27,7 +27,10 @@ const loaders = {
   Pet: {
     async owner(queries, context) {
       const petNames = queries.map(({ obj }) => obj.name)
-      return ownersByPetNames(context.app.pg, petNames)
+      const owners = await ownersByPetNames(context.app.pg, petNames)
+      return queries.map(({ obj: pet }) =>
+        owners.find(owner => owner.id === pet.owner)
+      )
     }
   }
 }

--- a/src/step-04-n+1/lib/db.js
+++ b/src/step-04-n+1/lib/db.js
@@ -9,12 +9,13 @@ export async function loadPets(db) {
 export async function ownersByPetNames(db, petNames) {
   const { rows } = await db.query(
     SQL`
-      SELECT owners.*
-      FROM owners
-      INNER JOIN pets
-        ON pets.owner = owners.id
-        AND pets.name = ANY(${petNames})
-    `
+    SELECT owners.*
+    FROM owners
+    INNER JOIN pets
+      ON pets.owner = owners.id
+      AND pets.name = ANY(${petNames})
+    ORDER BY
+      ARRAY_POSITION((${petNames}), pets.name)`
   )
 
   return rows

--- a/src/step-04-n+1/test/n+1.test.js
+++ b/src/step-04-n+1/test/n+1.test.js
@@ -32,13 +32,13 @@ test('should return owner of the pet', async t => {
       {
         name: 'Max',
         owner: {
-          name: 'Jennifer'
+          name: 'Simon'
         }
       },
       {
         name: 'Charlie',
         owner: {
-          name: 'Simon'
+          name: 'Jennifer'
         }
       }
     ]


### PR DESCRIPTION
Closes https://github.com/nearform/the-graphql-workshop/issues/485.

The changes make the queried owners paired with the pets.