### PR TITLE
Bump slidev to v0.42.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@mercuriusjs/federation": "^2.0.0",
         "@mercuriusjs/gateway": "^2.0.0",
         "@nearform/sql": "^1.10.5",
-        "@slidev/cli": "^0.42.8",
+        "@slidev/cli": "^0.42.9",
         "@slidev/theme-default": "^0.21.2",
         "@vueuse/shared": "^10.3.0",
         "desm": "^1.3.0",
@@ -1775,9 +1775,9 @@
       "dev": true
     },
     "node_modules/@slidev/cli": {
-      "version": "0.42.8",
-      "resolved": "https://registry.npmjs.org/@slidev/cli/-/cli-0.42.8.tgz",
-      "integrity": "sha512-CfrGlnMqXF/SvRbtOyM6eH0nYS9+cJHUG8yLp3pu4dYZUVw/hNpRPvnOZnxfZb19p6g448suVCi9htctDI0Iag==",
+      "version": "0.42.9",
+      "resolved": "https://registry.npmjs.org/@slidev/cli/-/cli-0.42.9.tgz",
+      "integrity": "sha512-JehwE5fL/CoIK7+CY3qw9IUcOnYw2L45S29jmmjb0cDEfDNz1J1YJDZQRc4o/DW//yZ9cuCLkQ4iaw+foCXLEg==",
       "dependencies": {
         "@antfu/utils": "^0.7.6",
         "@hedgedoc/markdown-it-plugins": "^2.1.3",
@@ -1785,9 +1785,9 @@
         "@iconify-json/ph": "^1.1.6",
         "@lillallol/outline-pdf": "^4.0.0",
         "@mrdrogdrog/optional": "^1.2.1",
-        "@slidev/client": "0.42.8",
-        "@slidev/parser": "0.42.8",
-        "@slidev/types": "0.42.8",
+        "@slidev/client": "0.42.9",
+        "@slidev/parser": "0.42.9",
+        "@slidev/types": "0.42.9",
         "@vitejs/plugin-vue": "^4.2.3",
         "@vitejs/plugin-vue-jsx": "^3.0.1",
         "@windicss/config": "^1.9.1",
@@ -1856,9 +1856,9 @@
       }
     },
     "node_modules/@slidev/cli/node_modules/@slidev/types": {
-      "version": "0.42.8",
-      "resolved": "https://registry.npmjs.org/@slidev/types/-/types-0.42.8.tgz",
-      "integrity": "sha512-YwQ63xJnUweFh2HO4FW7fVSdYVsGJzn1Di/+Qpxgcmm6x6RjX0QQ+w5NzYTxFzrvY/Nc5nGn6yhowGTkQjOFRg==",
+      "version": "0.42.9",
+      "resolved": "https://registry.npmjs.org/@slidev/types/-/types-0.42.9.tgz",
+      "integrity": "sha512-6jlN/ZpIyRuxroYT7U7VC/gLCelFxafQX4WXfjlglk3oyK3ytb8i8LiO3tHIEueWup2WlQRXNDJpVvqg25GlNA==",
       "engines": {
         "node": ">=14.0.0"
       },
@@ -1884,13 +1884,13 @@
       }
     },
     "node_modules/@slidev/client": {
-      "version": "0.42.8",
-      "resolved": "https://registry.npmjs.org/@slidev/client/-/client-0.42.8.tgz",
-      "integrity": "sha512-1KzcH8iaegZ64jDGxCHYt329yINh2iDOIWzFesRhLJPjWAAZPEShPFYhXOUDWnox8KAhPB9X/zZcGtFZ6QmUEw==",
+      "version": "0.42.9",
+      "resolved": "https://registry.npmjs.org/@slidev/client/-/client-0.42.9.tgz",
+      "integrity": "sha512-WmsY90Zy44+LvG8CBB++B2zI8jD39sGElhzcVDmrSpd70W6bYvf5rfXMzs2TxLdaR/qHmU2jYiNh+wQVsSKNIg==",
       "dependencies": {
         "@antfu/utils": "^0.7.6",
-        "@slidev/parser": "0.42.8",
-        "@slidev/types": "0.42.8",
+        "@slidev/parser": "0.42.9",
+        "@slidev/types": "0.42.9",
         "@unocss/reset": "^0.55.0",
         "@vueuse/core": "^10.3.0",
         "@vueuse/head": "^1.3.1",
@@ -1925,9 +1925,9 @@
       }
     },
     "node_modules/@slidev/client/node_modules/@slidev/types": {
-      "version": "0.42.8",
-      "resolved": "https://registry.npmjs.org/@slidev/types/-/types-0.42.8.tgz",
-      "integrity": "sha512-YwQ63xJnUweFh2HO4FW7fVSdYVsGJzn1Di/+Qpxgcmm6x6RjX0QQ+w5NzYTxFzrvY/Nc5nGn6yhowGTkQjOFRg==",
+      "version": "0.42.9",
+      "resolved": "https://registry.npmjs.org/@slidev/types/-/types-0.42.9.tgz",
+      "integrity": "sha512-6jlN/ZpIyRuxroYT7U7VC/gLCelFxafQX4WXfjlglk3oyK3ytb8i8LiO3tHIEueWup2WlQRXNDJpVvqg25GlNA==",
       "engines": {
         "node": ">=14.0.0"
       },
@@ -1953,11 +1953,11 @@
       }
     },
     "node_modules/@slidev/parser": {
-      "version": "0.42.8",
-      "resolved": "https://registry.npmjs.org/@slidev/parser/-/parser-0.42.8.tgz",
-      "integrity": "sha512-sJRIO0TrxLUIMAmCiDKOWFm86tFWJaKjwU8Y/T9+mkOOs02MM9aQ76AryehzfYaRyL97r+R1vyqKEVtztKEtGw==",
+      "version": "0.42.9",
+      "resolved": "https://registry.npmjs.org/@slidev/parser/-/parser-0.42.9.tgz",
+      "integrity": "sha512-7CHjWDJjv0Cu6tmaXGwcg7k3Vh4dM+W2ZcCBIb6wZ+UnG0s2vQVPc/2dxJc5VeU7qjw7s7yymEyeq0lX0Nd69w==",
       "dependencies": {
-        "@slidev/types": "0.42.8",
+        "@slidev/types": "0.42.9",
         "js-yaml": "^4.1.0"
       },
       "engines": {
@@ -1968,9 +1968,9 @@
       }
     },
     "node_modules/@slidev/parser/node_modules/@slidev/types": {
-      "version": "0.42.8",
-      "resolved": "https://registry.npmjs.org/@slidev/types/-/types-0.42.8.tgz",
-      "integrity": "sha512-YwQ63xJnUweFh2HO4FW7fVSdYVsGJzn1Di/+Qpxgcmm6x6RjX0QQ+w5NzYTxFzrvY/Nc5nGn6yhowGTkQjOFRg==",
+      "version": "0.42.9",
+      "resolved": "https://registry.npmjs.org/@slidev/types/-/types-0.42.9.tgz",
+      "integrity": "sha512-6jlN/ZpIyRuxroYT7U7VC/gLCelFxafQX4WXfjlglk3oyK3ytb8i8LiO3tHIEueWup2WlQRXNDJpVvqg25GlNA==",
       "engines": {
         "node": ">=14.0.0"
       },
@@ -14162,9 +14162,9 @@
       "dev": true
     },
     "@slidev/cli": {
-      "version": "0.42.8",
-      "resolved": "https://registry.npmjs.org/@slidev/cli/-/cli-0.42.8.tgz",
-      "integrity": "sha512-CfrGlnMqXF/SvRbtOyM6eH0nYS9+cJHUG8yLp3pu4dYZUVw/hNpRPvnOZnxfZb19p6g448suVCi9htctDI0Iag==",
+      "version": "0.42.9",
+      "resolved": "https://registry.npmjs.org/@slidev/cli/-/cli-0.42.9.tgz",
+      "integrity": "sha512-JehwE5fL/CoIK7+CY3qw9IUcOnYw2L45S29jmmjb0cDEfDNz1J1YJDZQRc4o/DW//yZ9cuCLkQ4iaw+foCXLEg==",
       "requires": {
         "@antfu/utils": "^0.7.6",
         "@hedgedoc/markdown-it-plugins": "^2.1.3",
@@ -14172,9 +14172,9 @@
         "@iconify-json/ph": "^1.1.6",
         "@lillallol/outline-pdf": "^4.0.0",
         "@mrdrogdrog/optional": "^1.2.1",
-        "@slidev/client": "0.42.8",
-        "@slidev/parser": "0.42.8",
-        "@slidev/types": "0.42.8",
+        "@slidev/client": "0.42.9",
+        "@slidev/parser": "0.42.9",
+        "@slidev/types": "0.42.9",
         "@vitejs/plugin-vue": "^4.2.3",
         "@vitejs/plugin-vue-jsx": "^3.0.1",
         "@windicss/config": "^1.9.1",
@@ -14226,9 +14226,9 @@
       },
       "dependencies": {
         "@slidev/types": {
-          "version": "0.42.8",
-          "resolved": "https://registry.npmjs.org/@slidev/types/-/types-0.42.8.tgz",
-          "integrity": "sha512-YwQ63xJnUweFh2HO4FW7fVSdYVsGJzn1Di/+Qpxgcmm6x6RjX0QQ+w5NzYTxFzrvY/Nc5nGn6yhowGTkQjOFRg=="
+          "version": "0.42.9",
+          "resolved": "https://registry.npmjs.org/@slidev/types/-/types-0.42.9.tgz",
+          "integrity": "sha512-6jlN/ZpIyRuxroYT7U7VC/gLCelFxafQX4WXfjlglk3oyK3ytb8i8LiO3tHIEueWup2WlQRXNDJpVvqg25GlNA=="
         },
         "nanoid": {
           "version": "4.0.2",
@@ -14238,13 +14238,13 @@
       }
     },
     "@slidev/client": {
-      "version": "0.42.8",
-      "resolved": "https://registry.npmjs.org/@slidev/client/-/client-0.42.8.tgz",
-      "integrity": "sha512-1KzcH8iaegZ64jDGxCHYt329yINh2iDOIWzFesRhLJPjWAAZPEShPFYhXOUDWnox8KAhPB9X/zZcGtFZ6QmUEw==",
+      "version": "0.42.9",
+      "resolved": "https://registry.npmjs.org/@slidev/client/-/client-0.42.9.tgz",
+      "integrity": "sha512-WmsY90Zy44+LvG8CBB++B2zI8jD39sGElhzcVDmrSpd70W6bYvf5rfXMzs2TxLdaR/qHmU2jYiNh+wQVsSKNIg==",
       "requires": {
         "@antfu/utils": "^0.7.6",
-        "@slidev/parser": "0.42.8",
-        "@slidev/types": "0.42.8",
+        "@slidev/parser": "0.42.9",
+        "@slidev/types": "0.42.9",
         "@unocss/reset": "^0.55.0",
         "@vueuse/core": "^10.3.0",
         "@vueuse/head": "^1.3.1",
@@ -14273,9 +14273,9 @@
       },
       "dependencies": {
         "@slidev/types": {
-          "version": "0.42.8",
-          "resolved": "https://registry.npmjs.org/@slidev/types/-/types-0.42.8.tgz",
-          "integrity": "sha512-YwQ63xJnUweFh2HO4FW7fVSdYVsGJzn1Di/+Qpxgcmm6x6RjX0QQ+w5NzYTxFzrvY/Nc5nGn6yhowGTkQjOFRg=="
+          "version": "0.42.9",
+          "resolved": "https://registry.npmjs.org/@slidev/types/-/types-0.42.9.tgz",
+          "integrity": "sha512-6jlN/ZpIyRuxroYT7U7VC/gLCelFxafQX4WXfjlglk3oyK3ytb8i8LiO3tHIEueWup2WlQRXNDJpVvqg25GlNA=="
         },
         "nanoid": {
           "version": "4.0.2",
@@ -14285,18 +14285,18 @@
       }
     },
     "@slidev/parser": {
-      "version": "0.42.8",
-      "resolved": "https://registry.npmjs.org/@slidev/parser/-/parser-0.42.8.tgz",
-      "integrity": "sha512-sJRIO0TrxLUIMAmCiDKOWFm86tFWJaKjwU8Y/T9+mkOOs02MM9aQ76AryehzfYaRyL97r+R1vyqKEVtztKEtGw==",
+      "version": "0.42.9",
+      "resolved": "https://registry.npmjs.org/@slidev/parser/-/parser-0.42.9.tgz",
+      "integrity": "sha512-7CHjWDJjv0Cu6tmaXGwcg7k3Vh4dM+W2ZcCBIb6wZ+UnG0s2vQVPc/2dxJc5VeU7qjw7s7yymEyeq0lX0Nd69w==",
       "requires": {
-        "@slidev/types": "0.42.8",
+        "@slidev/types": "0.42.9",
         "js-yaml": "^4.1.0"
       },
       "dependencies": {
         "@slidev/types": {
-          "version": "0.42.8",
-          "resolved": "https://registry.npmjs.org/@slidev/types/-/types-0.42.8.tgz",
-          "integrity": "sha512-YwQ63xJnUweFh2HO4FW7fVSdYVsGJzn1Di/+Qpxgcmm6x6RjX0QQ+w5NzYTxFzrvY/Nc5nGn6yhowGTkQjOFRg=="
+          "version": "0.42.9",
+          "resolved": "https://registry.npmjs.org/@slidev/types/-/types-0.42.9.tgz",
+          "integrity": "sha512-6jlN/ZpIyRuxroYT7U7VC/gLCelFxafQX4WXfjlglk3oyK3ytb8i8LiO3tHIEueWup2WlQRXNDJpVvqg25GlNA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@mercuriusjs/federation": "^2.0.0",
     "@mercuriusjs/gateway": "^2.0.0",
     "@nearform/sql": "^1.10.5",
-    "@slidev/cli": "^0.42.8",
+    "@slidev/cli": "^0.42.9",
     "@slidev/theme-default": "^0.21.2",
     "@vueuse/shared": "^10.3.0",
     "desm": "^1.3.0",


### PR DESCRIPTION
The workshop [failed to deploy](https://github.com/nearform/the-graphql-workshop/actions/runs/5925560492/job/16097538281) yesterday due to a bug in the Slidev CLI v0.42.8, similar to this closed [issue](https://github.com/slidevjs/slidev/issues/954). I have bumped the version to v0.42.9 and ran the failing deployed step locally to test that it is working.