### PR TITLE
chore(ci): make tests run on windows as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-      - run: pg_isready
       - run: npm ci
       - run: npm run db:migrate
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,7 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -40,8 +34,25 @@ jobs:
       - run: npm run db:migrate
       - run: npm test
 
+  build_windows:
+    runs-on: windows-latest
+    steps:
+      - name: Setup PostgreSQL for Linux/macOS/Windows
+        uses: ikalnytskyi/action-setup-postgres@v7
+        id: postgres
+        with:
+          port: 5433
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - run: pg_isready
+      - run: npm ci
+      - run: npm run db:migrate
+      - run: npm test
+
   automerge:
-    needs: build
+    needs: [build, build_windows]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  build:
+  build_linux:
     runs-on: ubuntu-latest
 
     services:
@@ -51,7 +51,7 @@ jobs:
       - run: npm test
 
   automerge:
-    needs: [build, build_windows]
+    needs: [build_linux, build_windows]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
+
     services:
       postgres:
         image: postgres:alpine
@@ -38,6 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: write  
+      contents: write
     steps:
       - uses: fastify/github-action-merge-dependabot@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "mercurius": "^15.1.0",
         "pg": "^8.13.1",
         "pino-pretty": "^13.0.0",
-        "postgrator-cli": "^9.0.0",
+        "postgrator-cli": "^9.0.1",
         "slidev-theme-nearform": "^2.0.0"
       },
       "devDependencies": {
@@ -8995,9 +8995,9 @@
       "license": "MIT"
     },
     "node_modules/lilconfig": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
-      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "engines": {
         "node": ">=14"
       },
@@ -11174,16 +11174,16 @@
       }
     },
     "node_modules/postgrator-cli": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/postgrator-cli/-/postgrator-cli-9.0.0.tgz",
-      "integrity": "sha512-uhxChTkGQspbN0L+nBPxm6qwMH7ZAnqI2NWgkEdaPjJ2c2MSUqnWnoTlTqOQ8zh5Tsp6PNLMUIOAyUOkN0tBhw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/postgrator-cli/-/postgrator-cli-9.0.1.tgz",
+      "integrity": "sha512-3JqdJ+BGgPy7zFeO/GI+SaYuKxe0x0ky1kPixg3cp6sVmevgkehlox0tp1t8YpZVNeJLFRobvMmB6qwnELvUlQ==",
       "dependencies": {
         "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.3",
-        "lilconfig": "^3.1.2",
+        "lilconfig": "^3.1.3",
         "p-tap": "^4.0.0",
         "postgrator": "^8.0.0",
-        "yaml": "^2.6.0"
+        "yaml": "^2.7.0"
       },
       "bin": {
         "postgrator": "index.js"
@@ -11213,9 +11213,9 @@
       }
     },
     "node_modules/postgrator-cli/node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -22364,9 +22364,9 @@
       }
     },
     "lilconfig": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
-      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="
     },
     "linkify-it": {
       "version": "5.0.0",
@@ -23970,22 +23970,22 @@
       }
     },
     "postgrator-cli": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/postgrator-cli/-/postgrator-cli-9.0.0.tgz",
-      "integrity": "sha512-uhxChTkGQspbN0L+nBPxm6qwMH7ZAnqI2NWgkEdaPjJ2c2MSUqnWnoTlTqOQ8zh5Tsp6PNLMUIOAyUOkN0tBhw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/postgrator-cli/-/postgrator-cli-9.0.1.tgz",
+      "integrity": "sha512-3JqdJ+BGgPy7zFeO/GI+SaYuKxe0x0ky1kPixg3cp6sVmevgkehlox0tp1t8YpZVNeJLFRobvMmB6qwnELvUlQ==",
       "requires": {
         "command-line-args": "^6.0.1",
         "command-line-usage": "^7.0.3",
-        "lilconfig": "^3.1.2",
+        "lilconfig": "^3.1.3",
         "p-tap": "^4.0.0",
         "postgrator": "^8.0.0",
-        "yaml": "^2.6.0"
+        "yaml": "^2.7.0"
       },
       "dependencies": {
         "yaml": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-          "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ=="
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+          "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mercurius": "^15.1.0",
     "pg": "^8.13.1",
     "pino-pretty": "^13.0.0",
-    "postgrator-cli": "^9.0.0",
+    "postgrator-cli": "^9.0.1",
     "slidev-theme-nearform": "^2.0.0"
   }
 }


### PR DESCRIPTION
Fixes [734](https://github.com/nearform/the-graphql-workshop/issues/734)

Currently the CI build will fail at the `db:migrate` step on Windows due to https://github.com/MattiLehtinen/postgrator-cli/issues/261, however I have also ran the CI build against my own branch https://github.com/Pupix/postgrator-cli/tree/fix/windows-relative-path and everything works as expected.

Will have to wait for them to merge and release a new minor version to properly test it.