### PR TITLE
chore: ignore graphql major updates until mercurius supports v17

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # graphql 17 is blocked by mercurius, whose peer range is ^16.0.0.
+      # Remove this once a mercurius release ships graphql 17 support
+      # (mercurius-js/mercurius#1256). See issue #1019.
+      - dependency-name: graphql
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Closes #1019

## Why

Dependabot PR #986 (`bump graphql from 16.14.2 to 17.0.2`) had `build_linux` and `build_windows` red since 2026-08-04. `npm ci` failed at install:

```
npm error While resolving: mercurius@16.10.0
npm error Found: graphql@17.0.2
npm error Could not resolve dependency:
npm error peer graphql@"^16.0.0" from mercurius@16.10.0
```

`mercurius@16.10.0` is the latest published release and still peers `graphql@^16.0.0`. `@mercuriusjs/federation@5.1.1` and `@mercuriusjs/gateway@5.2.0` both depend on `mercurius@^16.0.0`, so the constraint cannot be routed around.

The upstream fix — mercurius-js/mercurius#1256 — is open and unmerged. Per its description, **73 of 376** mercurius tests fail under graphql 17 without it (`buildExecutionContext` was removed from `graphql/execution/execute` in v17). Forcing the resolution via `--legacy-peer-deps` or `overrides` would make the install pass and break the workshop at runtime, so #986 was closed as unmergeable.

## What

Adds a Dependabot `ignore` rule so the same unmergeable PR is not re-raised every week:

```yaml
    ignore:
      - dependency-name: graphql
        update-types:
          - version-update:semver-major
```

`update-types: [version-update:semver-major]` rather than a `versions: [">=17"]` pin — this keeps graphql 16.x minor and patch updates flowing, and needs no edit when 18 eventually appears.

`package.json` and `package-lock.json` are untouched; `master` stays on `graphql@^16.14.2`, which resolves cleanly.

Remove this rule once a mercurius release ships graphql 17 support — tracked in #1019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)